### PR TITLE
Workaround for key names in PReg value names

### DIFF
--- a/gpoa/frontend/systemd_applier.py
+++ b/gpoa/frontend/systemd_applier.py
@@ -35,6 +35,11 @@ class systemd_applier(applier_frontend):
         '''
         for setting in self.systemd_unit_settings:
             valuename = setting.hive_key.rpartition('\\')[2]
+            valuename_extension_test = valuename.rpartition('_')
+
+            if valuename_extension_test[2] == 'service':
+                valuename = '{}.{}'.format(valuename_extension_test[0], valuename_extension_test[2])
+
             try:
                 self.units.append(systemd_unit(valuename, int(setting.data)))
                 logging.info(slogm('Working with systemd unit {}'.format(valuename)))


### PR DESCRIPTION
According to commit `601f432043be9c63b3675753c799aa4466753c66` in
`admx-basealt` there may be no dot symbols in PReg value names. This
commit adds workaround to transform '_' into '.' in systemd units'
names.

Please note that in the future systemd applier module might be
transformed to work with `Services.xml` file instead `Registry.pol` so
this clunky behavior won't be needed.