### PR TITLE
gpt.gpt: Polfile merging quickfix

### DIFF
--- a/gpoa/gpt/gpt.py
+++ b/gpoa/gpt/gpt.py
@@ -194,7 +194,7 @@ class gpt:
                 util.preg.merge_polfile(self._machine_regpol)
             if self._user_regpol:
                 logging.debug(slogm('Merging machine(user) settings from {}'.format(self._machine_regpol)))
-                util.preg.merge_polfile(self._user_regpol, self.machine_sid)
+                util.preg.merge_polfile(self._user_regpol, self.sid)
             if self._machine_shortcuts:
                 logging.debug(slogm('Merging machine shortcuts from {}'.format(self._machine_shortcuts)))
                 self._merge_shortcuts()


### PR DESCRIPTION
There is no `machine_sid` variable and I was unable to find when it was eliminated. Anyway, the fix is pretty simple. The bug related is: https://github.com/altlinux/gpupdate/issues/31 .