### PR TITLE
D-Bus exception catch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__
 *~
+_opam
+_build
+

--- a/doc/gpupdate.1
+++ b/doc/gpupdate.1
@@ -44,6 +44,22 @@ Show help.
 \fB--user \fIusername\fR
 Run \fBgpupdate\fP for \fIusername\fP.
 .
+.SS "EXIT CODES"
+.TP
+\fB0\fR
+Application exited successfully.
+.TP
+\fB1\fR
+No runner is able to start \fBgpoa\fR.
+.TP
+\fB2\fR
+No reply from \fID-Bus\fR when starting \fBgpoa\fR for computer using
+\fBoddjobd\fR via \fID-Bus\fR.
+.TP
+\fB3\fR
+No reply from \fID-Bus\fR when starting \fBgpoa\fR for user using
+\fBoddjobd\fR via \fID-Bus\fR.
+.
 .SH "SEE ALSO"
 gpoa(1)
 .SH BUGS

--- a/gpoa/gpupdate
+++ b/gpoa/gpupdate
@@ -29,7 +29,8 @@ from util.users import (
     is_root
 )
 from util.arguments import (
-    process_target
+    process_target,
+    ExitCodeUpdater
 )
 from util.dbus import (
     is_oddjobd_gpupdate_accessible,
@@ -132,14 +133,27 @@ def runner_factory(args, target):
 def main():
     args = parse_cli_arguments()
     gpo_appliers = runner_factory(args, process_target(args.target))
+
     if gpo_appliers:
         if gpo_appliers[0]:
-            gpo_appliers[0].run()
+            try:
+                gpo_appliers[0].run()
+            except Exception as exc:
+                logging.error('Error running GPOA for computer: {}'.format(exc))
+                return int(ExitCodeUpdater.FAIL_GPUPDATE_COMPUTER_NOREPLY)
+
         if gpo_appliers[1]:
-            gpo_appliers[1].run()
+            try:
+                gpo_appliers[1].run()
+            except Exception as exc:
+                logging.error('Error running GPOA for user: {}'.format(exc))
+                return int(ExitCodeUpdater.FAIL_GPUPDATE_USER_NOREPLY)
     else:
         logging.error('gpupdate will not be started')
+        return int(ExitCodeUpdater.FAIL_NO_RUNNER)
+
+    return int(ExitCodeUpdater.EXIT_SUCCESS)
 
 if __name__ == '__main__':
-    main()
+    sys.exit(int(main()))
 

--- a/gpoa/util/arguments.py
+++ b/gpoa/util/arguments.py
@@ -18,6 +18,7 @@
 
 import logging
 import logging.handlers
+from enum import IntEnum
 
 from .logging import slogm
 
@@ -74,4 +75,13 @@ def process_target(target_name=None):
     logging.debug(slogm('Target is: {}'.format(target)))
 
     return target
+
+class ExitCodeUpdater(IntEnum):
+    '''
+    Exit code contract for gpupdate application
+    '''
+    EXIT_SUCCESS = 0
+    FAIL_NO_RUNNER = 1
+    FAIL_GPUPDATE_COMPUTER_NOREPLY = 2
+    FAIL_GPUPDATE_USER_NOREPLY = 3
 

--- a/gpoa/util/dbus.py
+++ b/gpoa/util/dbus.py
@@ -43,14 +43,27 @@ class dbus_runner:
         if self.username:
             logging.info(slogm('Starting GPO applier for user {} via D-Bus'.format(self.username)))
             if is_root():
-                result = self.interface.gpupdatefor(dbus.String(self.username))
+                try:
+                    result = self.interface.gpupdatefor(dbus.String(self.username))
+                    print_dbus_result(result)
+                except dbus.exceptions.DBusException as exc:
+                    logging.error(slogm('No reply from oddjobd gpoa runner for {}'.format(self.username)))
+                    raise exc
             else:
-                result = self.interface.gpupdate()
-            print_dbus_result(result)
+                try:
+                    result = self.interface.gpupdate()
+                    print_dbus_result(result)
+                except dbus.exceptions.DBusException as exc:
+                    logging.error(slogm('No reply from oddjobd gpoa runner for current user'))
+                    raise exc
         else:
             logging.info(slogm('Starting GPO applier for computer via D-Bus'))
-            result = self.interface.gpupdate_computer()
-            print_dbus_result(result)
+            try:
+                result = self.interface.gpupdate_computer()
+                print_dbus_result(result)
+            except dbus.exceptions.DBusException as exc:
+                logging.error(slogm('No reply from oddjobd gpoa runner for computer'))
+                raise exc
         #self.interface.Quit()
 
 


### PR DESCRIPTION
When we try to start `oddjobd` via `D-Bus` using gpupdate we may
get the following traceback:

```
Traceback (most recent call last):
  File "/usr/bin/gpupdate", line 144, in <module>
    main()
  File "/usr/bin/gpupdate", line 139, in main
    gpo_appliers[1].run()
  File "/usr/lib/python3/site-packages/gpoa/util/dbus.py", line 48, in run
    result = self.interface.gpupdate()
  File "/usr/lib64/python3/site-packages/dbus/proxies.py", line 72, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib64/python3/site-packages/dbus/proxies.py", line 147, in __call__
    **keywords)
  File "/usr/lib64/python3/site-packages/dbus/connection.py", line 653, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NoReply: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
```

This PR catches this traceback, re-raises the exception and
establishes contract for `gpupdate` utility exit codes on fatal errors.