### PR TITLE
Fix service state handling

### DIFF
--- a/gpoa/frontend/appliers/systemd.py
+++ b/gpoa/frontend/appliers/systemd.py
@@ -40,14 +40,23 @@ class systemd_unit:
             self.manager.EnableUnitFiles([self.unit_name], dbus.Boolean(False), dbus.Boolean(True))
             self.manager.StartUnit(self.unit_name, 'replace')
             logging.info(slogm('Starting systemd unit: {}'.format(self.unit_name)))
-            if self._get_state() != 'active':
+
+            # In case the service has 'RestartSec' property set it
+            # switches to 'activating (auto-restart)' state instead of
+            # 'active' so we consider 'activating' a valid state too.
+            service_state = self._get_state()
+
+            if not service_state in ['active', 'activating']:
                 logging.error(slogm('Unable to start systemd unit {}'.format(self.unit_name)))
         else:
             self.manager.StopUnit(self.unit_name, 'replace')
             self.manager.DisableUnitFiles([self.unit_name], dbus.Boolean(False))
             self.manager.MaskUnitFiles([self.unit_name], dbus.Boolean(False), dbus.Boolean(True))
             logging.info(slogm('Stopping systemd unit: {}'.format(self.unit_name)))
-            if self._get_state() != 'stopped':
+
+            service_state = self._get_state()
+
+            if not service_state in ['stopped']:
                 logging.error(slogm('Unable to stop systemd unit {}'.format(self.unit_name)))
 
     def _get_state(self):


### PR DESCRIPTION
This commit fixes error on `gpupdate.service` unit start:

```
Unable to start systemd unit gpupdate.service
```

This error was caused by limited functionality on handling unit
states, especially for restartable units.