### PR TITLE
RPM helper improved

### DIFF
--- a/gpoa/test/util/test_rpm.py
+++ b/gpoa/test/util/test_rpm.py
@@ -20,18 +20,18 @@
 import unittest
 
 from util.rpm import (
-      install_rpm
-    , remove_rpm
+      install_rpms
+    , remove_rpms
 )
 
 class RPMTestCase(unittest.TestCase):
     @unittest.skip('test_install_rpm is not unit test')
     def test_install_rpm(self):
         test_package_names = ['tortoisehg', 'csync']
-        install_rpm(test_package_names, force=False, single_call=False)
+        install_rpms(test_package_names)
 
     @unittest.skip('test_remove_rpm is not unit test')
     def test_remove_rpm(self):
         test_package_names = ['tortoisehg', 'csync']
-        util.rpm.remove_rpm(test_package_names, force=False, single_call=False)
+        remove_rpms(test_package_names)
 

--- a/gpoa/test/util/test_rpm.py
+++ b/gpoa/test/util/test_rpm.py
@@ -1,0 +1,37 @@
+#
+# GPOA - GPO Applier for Linux
+#
+# Copyright (C) 2019-2020 BaseALT Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from util.rpm import (
+      install_rpm
+    , remove_rpm
+)
+
+class RPMTestCase(unittest.TestCase):
+    @unittest.skip('test_install_rpm is not unit test')
+    def test_install_rpm(self):
+        test_package_names = ['tortoisehg', 'csync']
+        install_rpm(test_package_names, force=False, single_call=False)
+
+    @unittest.skip('test_remove_rpm is not unit test')
+    def test_remove_rpm(self):
+        test_package_names = ['tortoisehg', 'csync']
+        util.rpm.remove_rpm(test_package_names, force=False, single_call=False)
+

--- a/gpoa/util/rpm.py
+++ b/gpoa/util/rpm.py
@@ -36,7 +36,7 @@ def is_rpm_installed(rpm_name):
 class Package:
     __install_command = ['/usr/bin/apt-get', '-y', 'install']
     __remove_command = ['/usr/bin/apt-get', '-y', 'remove']
-
+    __reinstall_command = ['/usr/bin/apt-get', '-y', 'reinstall']
 
     def __init__(self, package_name):
         self.package_name = package_name
@@ -73,6 +73,11 @@ class Package:
 
     def install(self):
         fullcmd = self.__install_command
+        fullcmd.append(self.package_name)
+        return subprocess.check_call(fullcmd)
+
+    def reinstall(self):
+        fullcmd = self.__reinstall_command
         fullcmd.append(self.package_name)
         return subprocess.check_call(fullcmd)
 

--- a/gpoa/util/rpm.py
+++ b/gpoa/util/rpm.py
@@ -92,71 +92,46 @@ class Package:
     def __str__(self):
         return self.package_name
 
-
 def update():
     '''
     Update APT-RPM database.
     '''
     subprocess.check_call(['/usr/bin/apt-get', 'update'])
 
-def install_rpm(rpm_names, force=True, single_call=True):
+def install_rpm(rpm_name):
     '''
-    Install RPM from APT-RPM sources.
-
-    :param rpm_names: List of names of RPM packages to install
-    :param force: Check if RPM is installed
+    Install single RPM
     '''
-    install_command = ['/usr/bin/apt-get', '-y', 'install']
-
-    package_list = [Package(rpm_name) for rpm_name in rpm_names]
-
     update()
+    rpm = Package(rpm_name)
+    return rpm.install()
 
-    filtered_package_list = list()
-    if not force:
-        for package in package_list:
-            if (not package.is_installed()) and package.is_for_install():
-                filtered_package_list.append(package)
-
-            if package.is_installed() and package.is_for_removal():
-                filtered_package_list.append(package)
-    else:
-        filtered_package_list = package_list()
-
-    if len(filtered_package_list) > 0:
-        if single_call:
-            string_filtered_list = [str(x) for x in filtered_package_list]
-            install_command.extend(string_filtered_list)
-            subprocess.check_call(install_command)
-        else:
-            for package in filtered_package_list:
-                package.action()
-
-def remove_rpm(rpm_names, force=True, single_call=True):
+def remove_rpm(rpm_name):
     '''
-    Remove RPM from file system.
-
-    :param rpm_names: List of names of RPM packages to install
-    :param force: Don't check if rpm is installed
+    Remove single RPM
     '''
-    remove_command = ['/usr/bin/apt-get', '-y', 'remove']
+    rpm = Package(rpm_name)
+    return rpm.remove()
 
-    package_list = [Package(rpm_name) for rpm_name in rpm_names]
+def install_rpms(rpm_names):
+    '''
+    Install set of RPMs sequentially
+    '''
+    result = list()
 
-    filtered_package_list = list()
-    if not force:
-        for package in package_list:
-            if package.is_installed() and package.is_for_removal():
-                filtered_package_list.append(package)
-    else:
-        filtered_package_list = package_list
+    for package in rpm_names:
+        result.append(install_rpm(package))
 
-    if len(filtered_package_list) > 0:
-        if single_call:
-            string_filtered_list = [str(x) for x in filtered_package_list]
-            remove_command.extend(string_filtered_list)
-            subprocess.check_call(remove_command)
-        else:
-            for package in filtered_package_list:
-                package.action()
+    return result
+
+def remove_rpms(rpm_names):
+    '''
+    Remove set of RPMs requentially
+    '''
+    result = list()
+
+    for package in rpm_names:
+        result.append(remove_rpm(package))
+
+    return result
 

--- a/gpoa/util/rpm.py
+++ b/gpoa/util/rpm.py
@@ -33,6 +33,60 @@ def is_rpm_installed(rpm_name):
 
     return False
 
+class Package:
+    __install_command = ['/usr/bin/apt-get', '-y', 'install']
+    __remove_command = ['/usr/bin/apt-get', '-y', 'remove']
+
+
+    def __init__(self, package_name):
+        self.package_name = package_name
+        self.for_install = True
+
+        if package_name.endswith('-'):
+            self.package_name = package_name[:-1]
+            self.for_install = False
+
+        self.installed = is_rpm_installed(self.package_name)
+
+    def mark_for_install(self):
+        self.for_install = True
+
+    def mark_for_removal(self):
+        self.for_install = False
+
+    def is_installed(self):
+        return self.installed
+
+    def is_for_install(self):
+        return self.for_install
+
+    def is_for_removal(self):
+        return (not self.for_install)
+
+    def action(self):
+        if self.for_install:
+            if not self.is_installed():
+                return self.install()
+        else:
+            if self.is_installed():
+                return self.remove()
+
+    def install(self):
+        fullcmd = self.__install_command
+        fullcmd.append(self.package_name)
+        return subprocess.check_call(fullcmd)
+
+    def remove(self):
+        fullcmd = self.__remove_command
+        fullcmd.append(self.package_name)
+        return subprocess.check_call(fullcmd)
+
+    def __repr__(self):
+        return self.package_name
+
+    def __str__(self):
+        return self.package_name
+
 
 def update():
     '''
@@ -40,44 +94,64 @@ def update():
     '''
     subprocess.check_call(['/usr/bin/apt-get', 'update'])
 
-
-def install_rpm(rpm_names, force=True):
+def install_rpm(rpm_names, force=True, single_call=True):
     '''
     Install RPM from APT-RPM sources.
 
     :param rpm_names: List of names of RPM packages to install
     :param force: Check if RPM is installed
     '''
-
     install_command = ['/usr/bin/apt-get', '-y', 'install']
 
+    package_list = [Package(rpm_name) for rpm_name in rpm_names]
+
     update()
-    if force:
-        for package in rpm_names:
-            if not is_rpm_installed(package)
-                install_command.append(package)
+
+    filtered_package_list = list()
+    if not force:
+        for package in package_list:
+            if (not package.is_installed()) and package.is_for_install():
+                filtered_package_list.append(package)
+
+            if package.is_installed() and package.is_for_removal():
+                filtered_package_list.append(package)
     else:
-        install_command.extend(rpm_names)
+        filtered_package_list = package_list()
 
-    subprocess.check_call(install_command)
+    if len(filtered_package_list) > 0:
+        if single_call:
+            string_filtered_list = [str(x) for x in filtered_package_list]
+            install_command.extend(string_filtered_list)
+            subprocess.check_call(install_command)
+        else:
+            for package in filtered_package_list:
+                package.action()
 
-def remove_rpm(rpm_names, force=True):
+def remove_rpm(rpm_names, force=True, single_call=True):
     '''
     Remove RPM from file system.
 
     :param rpm_names: List of names of RPM packages to install
-    :param force: Check if rpm is installed
+    :param force: Don't check if rpm is installed
     '''
     remove_command = ['/usr/bin/apt-get', '-y', 'remove']
 
-    update()
+    package_list = [Package(rpm_name) for rpm_name in rpm_names]
 
-    if force:
-        remove_command.extend(rpm_names)
+    filtered_package_list = list()
+    if not force:
+        for package in package_list:
+            if package.is_installed() and package.is_for_removal():
+                filtered_package_list.append(package)
     else:
-        for package in rpm_names:
-            if is_rpm_installed(package):
-                remove_command.append(package)
+        filtered_package_list = package_list
 
-    subprocess.check_call(remove_command)
+    if len(filtered_package_list) > 0:
+        if single_call:
+            string_filtered_list = [str(x) for x in filtered_package_list]
+            remove_command.extend(string_filtered_list)
+            subprocess.check_call(remove_command)
+        else:
+            for package in filtered_package_list:
+                package.action()
 

--- a/gpoa/util/rpm.py
+++ b/gpoa/util/rpm.py
@@ -41,17 +41,43 @@ def update():
     subprocess.check_call(['/usr/bin/apt-get', 'update'])
 
 
-def install_rpm(rpm_name):
+def install_rpm(rpm_names, force=True):
     '''
     Install RPM from APT-RPM sources.
+
+    :param rpm_names: List of names of RPM packages to install
+    :param force: Check if RPM is installed
     '''
+
+    install_command = ['/usr/bin/apt-get', '-y', 'install']
+
     update()
-    subprocess.check_call(['/usr/bin/apt-get', '-y', 'install', rpm_name])
+    if force:
+        for package in rpm_names:
+            if not is_rpm_installed(package)
+                install_command.append(package)
+    else:
+        install_command.extend(rpm_names)
 
+    subprocess.check_call(install_command)
 
-def remove_rpm(rpm_name):
+def remove_rpm(rpm_names, force=True):
     '''
     Remove RPM from file system.
+
+    :param rpm_names: List of names of RPM packages to install
+    :param force: Check if rpm is installed
     '''
-    subprocess.check_call(['/usr/bin/apt-get', '-y', 'remove', rpm_name])
+    remove_command = ['/usr/bin/apt-get', '-y', 'remove']
+
+    update()
+
+    if force:
+        remove_command.extend(rpm_names)
+    else:
+        for package in rpm_names:
+            if is_rpm_installed(package):
+                remove_command.append(package)
+
+    subprocess.check_call(remove_command)
 


### PR DESCRIPTION
This PR introduces additional checks if packages are installed. This pre-check before starting APT-RPM is needed to reduce APT memory consumption while scanning RPM database.