### PR TITLE
Error codes

### DIFF
--- a/gpoa/gpupdate
+++ b/gpoa/gpupdate
@@ -39,6 +39,8 @@ from util.dbus import (
 )
 from util.signals import signal_handler
 
+from messages import message_with_code
+
 logging.basicConfig(level=logging.DEBUG)
 
 class file_runner:
@@ -128,7 +130,7 @@ def runner_factory(args, target):
             user_runner = file_runner(username)
         return (computer_runner, user_runner)
     else:
-        logging.error('Insufficient permissions to run gpupdate')
+        logging.error(message_with_code('E1'))
 
     return None
 
@@ -151,7 +153,7 @@ def main():
                 logging.error('Error running GPOA for user: {}'.format(exc))
                 return int(ExitCodeUpdater.FAIL_GPUPDATE_USER_NOREPLY)
     else:
-        logging.error('gpupdate will not be started')
+        logging.error(message_with_code('E2'))
         return int(ExitCodeUpdater.FAIL_NO_RUNNER)
 
     return int(ExitCodeUpdater.EXIT_SUCCESS)

--- a/gpoa/messages/__init__.py
+++ b/gpoa/messages/__init__.py
@@ -1,0 +1,65 @@
+#
+# GPOA - GPO Applier for Linux
+#
+# Copyright (C) 2019-2020 BaseALT Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+def info_code(code):
+    info_ids = dict()
+    info_ids[1] = ''
+    info_ids[2] = ''
+
+    return info_ids.get(code, 'Unknown info code')
+
+def error_code(code):
+    error_ids = dict()
+    error_ids[1] = 'Insufficient permissions to run gpupdate'
+    error_ids[2] = 'gpupdate will not be started'
+
+    return error_ids.get(code, 'Unknown error code')
+
+def debug_code(code):
+    debug_ids = dict()
+    debug_ids[1] = ''
+    debug_ids[2] = ''
+
+    return debug_ids.get(code, 'Unknown debug code')
+
+def warning_code(code):
+    warning_ids = dict()
+    warning_ids[1] = ''
+    warning_ids[2] = ''
+
+    return warning_ids.get(code, 'Unknown warning code')
+
+def get_message(code):
+    retstr = 'Unknown message type, no message assigned'
+
+    if code.startswith('E'):
+        retstr = error_code(int(code[1:]))
+    if code.startswith('I'):
+        retstr = info_code(int(code[1:]))
+    if code.startswith('D'):
+        retstr = debug_code(int(code[1:]))
+    if code.startswith('W'):
+        retstr = warning_code(int(code[1:]))
+
+    return retstr
+
+def message_with_code(code):
+    retstr = '[' + code[0:1] + code[1:].rjust(5, '0') + ']: ' + get_message(code)
+
+    return retstr
+


### PR DESCRIPTION
`gpupdate`'s messaging/logging mechanism is shitty. This PR introduces new mechanism - all messages referenced by their codes, the English text is hardcoded into application by default and other texts must be accessible via `gettext`. The drawback of technology is that messages are not
format strings, so logging logic need to be reworked.

On the other hand there is still structured logging wrapper which may be able to provide the necessary data formatting.

The strong part of technology is that users will be able to reference messages by codes.