### PR TITLE
Use USER variable instead of unstable AUTOFS_UID

### DIFF
--- a/gpoa/templates/autofs_mountpoints.j2
+++ b/gpoa/templates/autofs_mountpoints.j2
@@ -17,5 +17,5 @@
  # along with this program.  If not, see <http://www.gnu.org/licenses/>.
  #}
 {%- for drv in drives %}
-{{ drv.dir }}	-fstype=cifs,cruid=$USER,sec=krb5	:{{ drv.path }}
+{{ drv.dir }}	-fstype=cifs,cruid=$USER,sec=krb5,noperm	:{{ drv.path }}
 {% endfor %}

--- a/gpoa/templates/autofs_mountpoints.j2
+++ b/gpoa/templates/autofs_mountpoints.j2
@@ -17,5 +17,5 @@
  # along with this program.  If not, see <http://www.gnu.org/licenses/>.
  #}
 {%- for drv in drives %}
-{{ drv.dir }}	-fstype=cifs,cruid=$AUTOFS_UID,sec=krb5	:{{ drv.path }}
+{{ drv.dir }}	-fstype=cifs,cruid=$USER,sec=krb5	:{{ drv.path }}
 {% endfor %}


### PR DESCRIPTION
`$AUTOFS_UID` is ALT-specific variable which proved to be unstable across distributions.