### PR TITLE
Fix TALLOC ownership problem in PReg parser

### DIFF
--- a/gpoa/util/preg.py
+++ b/gpoa/util/preg.py
@@ -91,10 +91,10 @@ def merge_polfile(preg, sid=None, reg_name='registry', reg_path=None, policy_nam
 
 class entry:
     def __init__(self, e_keyname, e_valuename, e_type, e_data):
-        logging.info(slogm('Entry init e_keyname {}'.format(e_keyname)))
-        logging.info(slogm('Entry init e_valuename {}'.format(e_valuename)))
-        logging.info(slogm('Entry init e_type {}'.format(e_type)))
-        logging.info(slogm('Entry init e_data {}'.format(e_data)))
+        logging.debug(slogm('Entry init e_keyname {}'.format(e_keyname)))
+        logging.debug(slogm('Entry init e_valuename {}'.format(e_valuename)))
+        logging.debug(slogm('Entry init e_type {}'.format(e_type)))
+        logging.debug(slogm('Entry init e_data {}'.format(e_data)))
         self.keyname = e_keyname
         self.valuename = e_valuename
         self.type = e_type

--- a/gpoa/util/preg.py
+++ b/gpoa/util/preg.py
@@ -59,10 +59,12 @@ def load_pol_preg(polfile):
 
     with open(polfile, 'rb') as f:
         data = f.read()
+        logging.debug('PReg length: {}'.format(len(data)))
         gpparser.parse(data)
 
     #print(gpparser.pol_file.__ndr_print__())
-    return gpparser.pol_file
+    pentries = preg2entries(gpparser.pol_file)
+    return pentries
 
 
 def preg_keymap(preg):
@@ -89,16 +91,24 @@ def merge_polfile(preg, sid=None, reg_name='registry', reg_path=None, policy_nam
 
 class entry:
     def __init__(self, e_keyname, e_valuename, e_type, e_data):
+        logging.info(slogm('Entry init e_keyname {}'.format(e_keyname)))
+        logging.info(slogm('Entry init e_valuename {}'.format(e_valuename)))
+        logging.info(slogm('Entry init e_type {}'.format(e_type)))
+        logging.info(slogm('Entry init e_data {}'.format(e_data)))
         self.keyname = e_keyname
         self.valuename = e_valuename
         self.type = e_type
         self.data = e_data
 
+class pentries:
+    def __init__(self):
+        self.entries = list()
+
 
 def preg2entries(preg_obj):
-    entries = []
-    for elem in prej_obj.entries:
+    entries = pentries()
+    for elem in preg_obj.entries:
         entry_obj = entry(elem.keyname, elem.valuename, elem.type, elem.data)
-        entries.append(entry_obj)
+        entries.entries.append(entry_obj)
     return entries
 


### PR DESCRIPTION
This commit fixes the following error:

```
2020-06-30 00:18:25:add_hkcu_entry: S-1-5-21-1609667327-4120075585-2415302043-1109 Software\BaseALT\Policies\GPUpdate 0 4
Traceback (most recent call last):
  File "/usr/sbin/gpoa", line 145, in <module>
    main()
  File "/usr/sbin/gpoa", line 140, in main
    controller.run()
  File "/usr/sbin/gpoa", line 97, in run
    self.start_backend()
  File "/usr/sbin/gpoa", line 115, in start_backend
    back.retrieve_and_store()
  File "/usr/lib/python3/site-packages/gpoa/backend/samba_backend.py", line 71, in retrieve_and_store
    gptobj.merge()
  File "/usr/lib/python3/site-packages/gpoa/gpt/gpt.py", line 219, in merge
    preference_merger(self.storage, self.sid, preference_objects, self.name)
  File "/usr/lib/python3/site-packages/gpoa/gpt/polfile.py", line 31, in merge_polfile
    storage.add_hkcu_entry(entry, sid, policy_name)
  File "/usr/lib/python3/site-packages/gpoa/storage/sqlite_registry.py", line 242, in add_hkcu_entry
    valname = preg_entry.valuename
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd2 in position 0: invalid continuation byte
```

This is the critical bug related to ownership problem in objects
managed by LIBTALLOC which leads to object destruction and freeing the
memory used by the object (and also corruption of this memory).

It is needed to transfer memory ownership from TALLOC to Python ASAP so
we're creating Python-managed object and copy the data into it.