### PR TITLE
Postinst trigger introduced

### DIFF
--- a/gpupdate.spec
+++ b/gpupdate.spec
@@ -76,6 +76,11 @@ install -Dm0644 doc/gpupdate.1 %buildroot/%_man1dir/gpupdate.1
 %post
 %post_service gpupdate
 
+# Remove storage in case we've lost compatibility between versions.
+# The storage will be regenerated on GPOA start.
+%triggerpostun -- %name > 0.7
+rm -f %_cachedir/%name/registry.sqlite
+
 %files
 %_sbindir/gpoa
 %_sbindir/gpupdate-setup


### PR DESCRIPTION
There are situations when we might lose storage compatibility between
versions due to SQLite3 table structure changes. This commit introduces
trigger which removes old storage in case of specific version change.

The storage will be regenerated on next GPOA run.