### PR TITLE
Added functionality to tune Samba backend via INI file

### DIFF
--- a/gpoa/backend/__init__.py
+++ b/gpoa/backend/__init__.py
@@ -34,6 +34,10 @@ def backend_factory(dc, username, is_machine, no_domain = False):
     config = GPConfig()
 
     if config.get_backend() == 'samba' and not no_domain:
+        if not dc:
+            dc = config.get_dc()
+            ld = dict({'dc': dc})
+            log('D52', ld)
         sc = smbcreds(dc)
         domain = sc.get_domain()
         ldata = dict({'domain': domain})

--- a/gpoa/locale/ru_RU/LC_MESSAGES/gpoa.po
+++ b/gpoa/locale/ru_RU/LC_MESSAGES/gpoa.po
@@ -286,6 +286,9 @@ msgstr "Завершена репликация GPO от контроллера 
 msgid "Skipping HKCU branch deletion key"
 msgstr "Пропускаем специальный ключ удаления ветви реестра HKCU"
 
+msgid "Read domain name from configuration file"
+msgstr "Имя контроллера домена для репликации прочитано из файла конфигурации"
+
 msgid "Unknown debug code"
 msgstr "Неизвестный отладочный код"
 

--- a/gpoa/messages/__init__.py
+++ b/gpoa/messages/__init__.py
@@ -113,6 +113,7 @@ def debug_code(code):
     debug_ids[49] = 'Started GPO replication from AD DC'
     debug_ids[50] = 'Finished GPO replication from AD DC'
     debug_ids[51] = 'Skipping HKCU branch deletion key'
+    debug_ids[52] = 'Read domain name from configuration file'
 
     return debug_ids.get(code, 'Unknown debug code')
 

--- a/gpoa/util/config.py
+++ b/gpoa/util/config.py
@@ -49,6 +49,17 @@ class GPConfig:
         self.full_config['gpoa']['backend'] = backend_name
         self.write_config()
 
+    # This function is not expected corresponding "set_dc()" function
+    # because we have no way to automatically determine such kind
+    # of setting.
+    def get_dc(self):
+        '''
+        Fetch Domain Controller from configuration file.
+        '''
+        if 'samba' in self.full_config:
+            if 'dc' in self.full_config['samba']:
+                return self.full_config['samba']['dc']
+
     def get_local_policy_template(self):
         '''
         Fetch the name of chosen Local Policy template from


### PR DESCRIPTION
It is now possible to write in `/etc/gpupdate/gpupdate.ini`:

```
[samba]
dc = your.buggy.dc
```

To avoid auto-selection of Domain Controller for policy replication.