### PR TITLE
Make registry keys case-insensitive like in Windows registry

### DIFF
--- a/gpoa/storage/sqlite_registry.py
+++ b/gpoa/storage/sqlite_registry.py
@@ -65,7 +65,8 @@ class sqlite_registry(registry):
               'HKLM'
             , self.__metadata
             , Column('id', Integer, primary_key=True)
-            , Column('hive_key', String(65536), unique=True)
+            , Column('hive_key', String(65536, collation='NOCASE'),
+                unique=True)
             , Column('policy_name', String)
             , Column('type', Integer)
             , Column('data', String)
@@ -75,7 +76,7 @@ class sqlite_registry(registry):
             , self.__metadata
             , Column('id', Integer, primary_key=True)
             , Column('sid', String)
-            , Column('hive_key', String(65536))
+            , Column('hive_key', String(65536, collation='NOCASE'))
             , Column('policy_name', String)
             , Column('type', Integer)
             , Column('data', String)


### PR DESCRIPTION
This PR is needed for case-insensitive comparison of `hive_key` field in `HKCU` and `HKLM` tables.