### PR TITLE
Windows mapping feature and dbus fixes

### DIFF
--- a/gpoa/frontend/applier_frontend.py
+++ b/gpoa/frontend/applier_frontend.py
@@ -32,6 +32,17 @@ def check_experimental_enabled(storage):
 
     return result
 
+def check_windows_mapping_enabled(storage):
+    windows_mapping_enable_flag = 'Software\\BaseALT\\Policies\\GPUpdate\\WindowsPoliciesMapping'
+    flag = storage.get_hklm_entry(windows_mapping_enable_flag)
+
+    result = True
+
+    if flag and '0' == flag.data:
+        result = False
+
+    return result
+
 def check_module_enabled(storage, module_name):
     gpupdate_module_enable_branch = 'Software\\BaseALT\\Policies\\GPUpdate'
     gpupdate_module_flag = '{}\\{}'.format(gpupdate_module_enable_branch, module_name)

--- a/gpoa/frontend/appliers/gsettings.py
+++ b/gpoa/frontend/appliers/gsettings.py
@@ -43,7 +43,7 @@ class system_gsetting:
 
         value = glib_value(self.schema, self.path, self.value)
         config.set(self.schema, self.path, str(value))
-        logging.debug('Setting GSettings key {} (in {}) to {}'.format(self.path, self.schema, str(value)))
+        #logging.debug('Setting GSettings key {} (in {}) to {}'.format(self.path, self.schema, str(value)))
 
         with open(self.file_path, 'w') as f:
             config.write(f)
@@ -71,14 +71,14 @@ def glib_value(schema, path, value, settings=None):
 
 class user_gsetting:
     def __init__(self, schema, path, value, helper_function=None):
-        logging.debug('Creating User GSettings element {} (in {}) with value {}'.format(path, schema, value))
+        #logging.debug('Creating User GSettings element {} (in {}) with value {}'.format(path, schema, value))
         self.schema = schema
         self.path = path
         self.value = value
         self.helper_function = helper_function
 
     def apply(self):
-        logging.debug('Setting User GSettings key {} (in {}) to {}'.format(self.path, self.schema, self.value))
+        #logging.debug('Setting User GSettings key {} (in {}) to {}'.format(self.path, self.schema, self.value))
         if self.helper_function:
             self.helper_function(self.schema, self.path, self.value)
         # Access the current schema

--- a/gpoa/frontend/gsettings_applier.py
+++ b/gpoa/frontend/gsettings_applier.py
@@ -79,6 +79,7 @@ class gsettings_applier(applier_frontend):
 
         # Create GSettings policy with highest available priority
         for gsetting in self.gsettings:
+            logging.debug(slogm('Applying setting {}/{} to {}'.format(gsetting.schema, gsetting.path, gsetting.value)))
             gsetting.apply()
 
         # Recompile GSettings schemas with overrides
@@ -216,7 +217,7 @@ class gsettings_applier_user(applier_frontend):
 
         # Create GSettings policy with highest available priority
         for gsetting in self.gsettings:
-            logging.debug('Applying setting {}/{}'.format(gsetting.schema, gsetting.path))
+            logging.debug(slogm('Applying user setting {}/{} to {}'.format(gsetting.schema, gsetting.path, gsetting.value)))
             gsetting.apply()
 
     def user_context_apply(self):

--- a/gpoa/messages/__init__.py
+++ b/gpoa/messages/__init__.py
@@ -123,6 +123,7 @@ def debug_code(code):
     debug_ids[55] = 'Run user context applier with dropped privileges'
     debug_ids[56] = 'Kill dbus-daemon and dconf-service in user context'
     debug_ids[57] = 'Found connection by org.freedesktop.DBus.GetConnectionUnixProcessID'
+    debug_ids[58] = 'Connection search return org.freedesktop.DBus.Error.NameHasNoOwner'
 
     return debug_ids.get(code, 'Unknown debug code')
 

--- a/gpoa/util/dbus.py
+++ b/gpoa/util/dbus.py
@@ -188,7 +188,9 @@ class dbus_session:
             pid = self.session_iface.GetConnectionUnixProcessID(connection)
             log('D57', {"pid": pid})
         except dbus.exceptions.DBusException as exc:
-            logdata = dict({'error': str(exc)})
-            log('E32', logdata)
-            raise exc
+            if exc.get_dbus_name() != 'org.freedesktop.DBus.Error.NameHasNoOwner':
+                logdata = dict({'error': str(exc)})
+                log('E32', logdata)
+                raise exc
+            log('D58', {'connection': connection})
         return int(pid)

--- a/gpoa/util/system.py
+++ b/gpoa/util/system.py
@@ -113,8 +113,12 @@ def with_privileges(username, func):
         func()
 
         # Save pid of dconf-service
-        session = dbus_session()
-        dconf_pid = session.get_connection_pid("ca.desrt.dconf")
+        dconf_connection = "ca.desrt.dconf"
+        try:
+            session = dbus_session()
+            dconf_pid = session.get_connection_pid(dconf_connection)
+        except Exception:
+            pass
 
     except Exception as exc:
         logdata = dict()


### PR DESCRIPTION
- Add new Software\BaseALT\Policies\GPUpdate\WindowsPoliciesMapping feature enables or disables GSettings mapping.
- Fix various debug info mesages during GSetting applying.
- Avoid error in forked process with dconf-service killing if dconf not using.