### PR TITLE
Added handling of quotation marks in Preference values

### DIFF
--- a/gpoa/gpt/dynamic_attributes.py
+++ b/gpoa/gpt/dynamic_attributes.py
@@ -26,6 +26,10 @@ class DynamicAttributes:
     def __setattr__(self, key, value):
         if isinstance(value, Enum):
             value = str(value)
+        if isinstance(value, str):
+            for q in ["'", "\""]:
+                if any(q in ch for ch in value):
+                    value = value.replace(q, "″")
         self.__dict__[key] = value
 
     def items(self):


### PR DESCRIPTION
I propose a fix related to the validation of Preference values.

**Problem**: if there were quotes inside a value, parsing from a binary file was impossible (string structure was broken for parsing with python tools: ast.literal_eval, ...).

**Solution**: replace quotation marks with a character similar to a quotation mark