### PR TITLE
Added machine policy exception handling to kde_applier

### DIFF
--- a/gpoa/frontend/kde_applier.py
+++ b/gpoa/frontend/kde_applier.py
@@ -52,9 +52,13 @@ class kde_applier(applier_frontend):
 
     def apply(self):
         if self.__module_enabled:
-            log('D198')
-            create_dict(self.kde_settings, self.all_kde_settings, self.locks_settings, self.locks_dict)
-            apply(self.all_kde_settings, self.locks_dict)
+            try:
+                log('D198')
+                create_dict(self.kde_settings, self.all_kde_settings, self.locks_settings, self.locks_dict)
+                apply(self.all_kde_settings, self.locks_dict)
+            except Exception as exc:
+                logdata = dict()
+                logdata['exc'] = exc
         else:
             log('D199')
 


### PR DESCRIPTION
Errors may occur when running apply for machine policy:
2025-04-16 12:18:38.807|[E00024]| Error occured while running machine applier|{'applier_name': 'kde', 'msg': “name ‘exc’ is not defined”}

Exception needs to be handled