### PR TITLE
Changed the logic for checking if the module is turned on

### DIFF
--- a/gpoa/frontend/applier_frontend.py
+++ b/gpoa/frontend/applier_frontend.py
@@ -60,17 +60,14 @@ def check_enabled(storage, module_name, is_experimental):
     module_enabled = check_module_enabled(storage, module_name)
     exp_enabled = check_experimental_enabled(storage)
 
-    result = False
-
-    if None == module_enabled:
-        if is_experimental and exp_enabled:
-            result = True
-        if not is_experimental:
-            result = True
+    if module_enabled is None:
+        return False
+    elif module_enabled and is_experimental and exp_enabled:
+        return True
+    elif module_enabled and not is_experimental:
+        return True
     else:
-        result = module_enabled
-
-    return result
+        return False
 
 class applier_frontend(ABC):
     @classmethod


### PR DESCRIPTION
Prior to this commit, machine applier applied custom policies due to bad logic in check_enabled() in the applier_frontend.py file.

It used to be like this
```
def check_enabled(storage, module_name, is_experimental):
    module_enabled = check_module_enabled(storage, module_name)
    exp_enabled = check_experimental_enabled(storage)

    result = False

    if None == module_enabled:
        if is_experimental and exp_enabled:
            result = True
        if not is_experimental:
            result = True
    else:
        result = module_enabled

    return result
```

If the module is not in dconf, we returned True for some reason and enabled it. This is not a very good approach.
With my commit, the logic got better. For the control applier to work, it must be enabled in the GPUI interface.